### PR TITLE
wally: Switch to upstream instead of fork

### DIFF
--- a/scgallery/designs/wally/wally.py
+++ b/scgallery/designs/wally/wally.py
@@ -17,8 +17,8 @@ def setup():
     chip = Chip('wally')
 
     chip.register_source('wally',
-                         path='git+https://github.com/infinitymdm/cvw',
-                         ref='6fafa7f8ff970e13ac32bec6fcfba7c6ac287520')
+                         path='git+https://github.com/openhwgroup/cvw',
+                         ref='e0af0e68a32edd8eb98abc31c8b2b7b04fbd29b9')
 
     chip.set('option', 'entrypoint', 'wallypipelinedcorewrapper')
 


### PR DESCRIPTION
With the recent fixes to slang, upstream wally now appears to work correctly with siliconcompiler. Switch from my fork (which had workarounds that are no longer required) to upstream wally.

My testing has made it through synthesis and floorplanning, so I'm reasonably confident it will work. However, I plan to keep this PR marked as a draft until it actually gets through write.gds.