### PR TITLE
add gt2n to matrix

### DIFF
--- a/.github/workflows/bin/generate_cache.py
+++ b/.github/workflows/bin/generate_cache.py
@@ -8,6 +8,7 @@ from lambdapdk.freepdk45 import FreePDK45PDK
 from lambdapdk.gf180 import GF180_5LM_1TM_9K_9t
 from lambdapdk.ihp130 import IHP130PDK
 from lambdapdk.sky130 import Sky130PDK
+from lambdapdk.gt2n import GT2NPDK
 
 
 if __name__ == "__main__":
@@ -20,6 +21,7 @@ if __name__ == "__main__":
     proj.add_dep(GF180_5LM_1TM_9K_9t())
     proj.add_dep(IHP130PDK())
     proj.add_dep(Sky130PDK())
+    proj.add_dep(GT2NPDK())
 
     proj.check_filepaths([("option", "builddir")])
 

--- a/.github/workflows/config/designs.json
+++ b/.github/workflows/config/designs.json
@@ -26,6 +26,11 @@
     {
         "design": "aes",
         "remote": false,
+        "target": "gt2n_6t_w31"
+    },
+    {
+        "design": "aes",
+        "remote": false,
         "target": "ihp130_sg13g2_stdcell"
     },
     {
@@ -102,6 +107,11 @@
     {
         "design": "blinky",
         "remote": false,
+        "target": "gt2n_6t_w31"
+    },
+    {
+        "design": "blinky",
+        "remote": false,
         "target": "ihp130_sg13g2_stdcell"
     },
     {
@@ -134,6 +144,14 @@
         "target": "gf180_gf180mcu_fd_sc_mcu9t5v0"
     },
     {
+        "cache": false,
+        "design": "caliptra_datavault",
+        "remote": false,
+        "skip": "Task ran out of memory",
+        "skip_class": "resource",
+        "target": "gt2n_6t_w31"
+    },
+    {
         "design": "caliptra_datavault",
         "remote": false,
         "target": "ihp130_sg13g2_stdcell"
@@ -183,6 +201,14 @@
         "remote": false,
         "skip": "Timed out on CI runner",
         "skip_class": "resource",
+        "target": "gt2n_6t_w31"
+    },
+    {
+        "cache": false,
+        "design": "caliptra_keyvault",
+        "remote": false,
+        "skip": "Timed out on CI runner",
+        "skip_class": "resource",
         "target": "ihp130_sg13g2_stdcell"
     },
     {
@@ -216,6 +242,14 @@
         "remote": false,
         "skip": "[ERROR GRT-0232] Routing congestion too high. Check the congestion heatmap in the GUI.",
         "target": "gf180_gf180mcu_fd_sc_mcu9t5v0"
+    },
+    {
+        "cache": false,
+        "design": "caliptra_sha512",
+        "remote": false,
+        "skip": "Task ran out of memory",
+        "skip_class": "resource",
+        "target": "gt2n_6t_w31"
     },
     {
         "design": "caliptra_sha512",
@@ -323,6 +357,11 @@
     {
         "design": "dynamic_node",
         "remote": false,
+        "target": "gt2n_6t_w31"
+    },
+    {
+        "design": "dynamic_node",
+        "remote": false,
         "target": "ihp130_sg13g2_stdcell"
     },
     {
@@ -415,6 +454,11 @@
     {
         "design": "gcd",
         "remote": false,
+        "target": "gt2n_6t_w31"
+    },
+    {
+        "design": "gcd",
+        "remote": false,
         "target": "ihp130_sg13g2_stdcell"
     },
     {
@@ -445,6 +489,11 @@
     {
         "design": "heartbeat",
         "remote": false,
+        "target": "gt2n_6t_w31"
+    },
+    {
+        "design": "heartbeat",
+        "remote": false,
         "target": "ihp130_sg13g2_stdcell"
     },
     {
@@ -471,6 +520,11 @@
         "design": "ibex",
         "remote": false,
         "target": "gf180_gf180mcu_fd_sc_mcu9t5v0"
+    },
+    {
+        "design": "ibex",
+        "remote": false,
+        "target": "gt2n_6t_w31"
     },
     {
         "design": "ibex",
@@ -505,6 +559,14 @@
         "target": "gf180_gf180mcu_fd_sc_mcu9t5v0"
     },
     {
+        "cache": false,
+        "design": "jpeg",
+        "remote": false,
+        "skip": "Task ran out of memory",
+        "skip_class": "resource",
+        "target": "gt2n_6t_w31"
+    },
+    {
         "design": "jpeg",
         "remote": false,
         "target": "ihp130_sg13g2_stdcell"
@@ -537,6 +599,11 @@
     {
         "design": "mock_alu",
         "remote": false,
+        "target": "gt2n_6t_w31"
+    },
+    {
+        "design": "mock_alu",
+        "remote": false,
         "target": "ihp130_sg13g2_stdcell"
     },
     {
@@ -567,6 +634,11 @@
     {
         "design": "openmsp430",
         "remote": false,
+        "target": "gt2n_6t_w31"
+    },
+    {
+        "design": "openmsp430",
+        "remote": false,
         "target": "ihp130_sg13g2_stdcell"
     },
     {
@@ -597,6 +669,11 @@
     {
         "design": "picorv32",
         "remote": false,
+        "target": "gt2n_6t_w31"
+    },
+    {
+        "design": "picorv32",
+        "remote": false,
         "target": "ihp130_sg13g2_stdcell"
     },
     {
@@ -627,6 +704,11 @@
     {
         "design": "qerv",
         "remote": false,
+        "target": "gt2n_6t_w31"
+    },
+    {
+        "design": "qerv",
+        "remote": false,
         "target": "ihp130_sg13g2_stdcell"
     },
     {
@@ -657,6 +739,11 @@
     {
         "design": "riscv32i",
         "remote": false,
+        "target": "gt2n_6t_w31"
+    },
+    {
+        "design": "riscv32i",
+        "remote": false,
         "target": "ihp130_sg13g2_stdcell"
     },
     {
@@ -687,6 +774,11 @@
     {
         "design": "serv",
         "remote": false,
+        "target": "gt2n_6t_w31"
+    },
+    {
+        "design": "serv",
+        "remote": false,
         "target": "ihp130_sg13g2_stdcell"
     },
     {
@@ -713,6 +805,11 @@
         "design": "spi",
         "remote": false,
         "target": "gf180_gf180mcu_fd_sc_mcu9t5v0"
+    },
+    {
+        "design": "spi",
+        "remote": false,
+        "target": "gt2n_6t_w31"
     },
     {
         "design": "spi",
@@ -750,6 +847,14 @@
         "remote": false,
         "skip": "[ERROR GRT-0232] Routing congestion too high. Check the congestion heatmap in the GUI.",
         "target": "gf180_gf180mcu_fd_sc_mcu9t5v0"
+    },
+    {
+        "cache": false,
+        "design": "swerv",
+        "remote": false,
+        "skip": "Task ran out of memory",
+        "skip_class": "resource",
+        "target": "gt2n_6t_w31"
     },
     {
         "cache": false,
@@ -820,6 +925,11 @@
         "design": "uart",
         "remote": false,
         "target": "gf180_gf180mcu_fd_sc_mcu9t5v0"
+    },
+    {
+        "design": "uart",
+        "remote": false,
+        "target": "gt2n_6t_w31"
     },
     {
         "design": "uart",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ license = "Apache-2.0"
 license-files = ["LICENSE"]
 dependencies = [
     "siliconcompiler>=0.37.3",
-    "lambdapdk>=0.2.11",
+    "lambdapdk>=0.2.13",
     "lambdalib>=0.12.0"
 ]
 dynamic = ["version"]

--- a/scgallery/designs/aes/aes.py
+++ b/scgallery/designs/aes/aes.py
@@ -34,6 +34,9 @@ class AESDesign(GalleryDesign):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 

--- a/scgallery/designs/aes/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/aes/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 1300
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/blinky/blinky.py
+++ b/scgallery/designs/blinky/blinky.py
@@ -23,6 +23,9 @@ class BlinkyDesign(Design):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 

--- a/scgallery/designs/blinky/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/blinky/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 425
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/caliptra/__init__.py
+++ b/scgallery/designs/caliptra/__init__.py
@@ -67,6 +67,9 @@ class DataVault(GalleryDesign, _Base):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/datavault/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/datavault/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/datavault/gf180mcu_fd_sc_mcu7t5v0.sdc")
 
@@ -83,6 +86,7 @@ class DataVault(GalleryDesign, _Base):
                 self.add_file("constraints/datavault/sky130hd.sdc")
 
         self.add_target_setup("freepdk45_nangate45", self.setup_freepdk45)
+        self.add_target_setup("gt2n_6t_w31", self.setup_gt2n)
         self.add_target_setup("asap7_asap7sc7p5t_rvt", self.setup_asap7)
         self.add_target_setup("ihp130_sg13g2_stdcell", self.setup_ihp130)
         self.add_target_setup("gf180_gf180mcu_fd_sc_mcu7t5v0", self.setup_gf180)
@@ -114,6 +118,12 @@ class DataVault(GalleryDesign, _Base):
             task.set_openroad_placedensity(0.40)
 
     def setup_skywater130(self, project: ASIC):
+        project.set_flow(SV2VFlow())
+        project.constraint.area.set_density(30)
+        for task in OpenROADGPLParameter.find_task(project):
+            task.set_openroad_placedensity(0.40)
+
+    def setup_gt2n(self, project: ASIC):
         project.set_flow(SV2VFlow())
         project.constraint.area.set_density(30)
         for task in OpenROADGPLParameter.find_task(project):
@@ -142,6 +152,9 @@ class KeyVault(GalleryDesign, _Base):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/keyvault/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/keyvault/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/keyvault/gf180mcu_fd_sc_mcu7t5v0.sdc")
 
@@ -158,6 +171,7 @@ class KeyVault(GalleryDesign, _Base):
                 self.add_file("constraints/keyvault/sky130hd.sdc")
 
         self.add_target_setup("freepdk45_nangate45", self.setup_freepdk45)
+        self.add_target_setup("gt2n_6t_w31", self.setup_gt2n)
         self.add_target_setup("asap7_asap7sc7p5t_rvt", self.setup_asap7)
         self.add_target_setup("ihp130_sg13g2_stdcell", self.setup_ihp130)
         self.add_target_setup("gf180_gf180mcu_fd_sc_mcu7t5v0", self.setup_gf180)
@@ -189,6 +203,12 @@ class KeyVault(GalleryDesign, _Base):
             task.set_openroad_placedensity(0.25)
 
     def setup_skywater130(self, project: ASIC):
+        project.set_flow(SV2VFlow())
+        project.constraint.area.set_density(20)
+        for task in OpenROADGPLParameter.find_task(project):
+            task.set_openroad_placedensity(0.25)
+
+    def setup_gt2n(self, project: ASIC):
         project.set_flow(SV2VFlow())
         project.constraint.area.set_density(20)
         for task in OpenROADGPLParameter.find_task(project):
@@ -237,6 +257,9 @@ class SHA512(GalleryDesign, _Base):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/sha512/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/sha512/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/sha512/gf180mcu_fd_sc_mcu7t5v0.sdc")
 
@@ -253,6 +276,7 @@ class SHA512(GalleryDesign, _Base):
                 self.add_file("constraints/sha512/sky130hd.sdc")
 
         self.add_target_setup("freepdk45_nangate45", self.setup_freepdk45)
+        self.add_target_setup("gt2n_6t_w31", self.setup_gt2n)
         self.add_target_setup("asap7_asap7sc7p5t_rvt", self.setup_asap7)
         self.add_target_setup("ihp130_sg13g2_stdcell", self.setup_ihp130)
         self.add_target_setup("gf180_gf180mcu_fd_sc_mcu7t5v0", self.setup_gf180)
@@ -288,3 +312,9 @@ class SHA512(GalleryDesign, _Base):
         project.constraint.area.set_density(30)
         for task in OpenROADGPLParameter.find_task(project):
             task.set_openroad_placedensity(0.4)
+
+    def setup_gt2n(self, project: ASIC):
+        project.set_flow(SV2VFlow())
+        project.constraint.area.set_density(30)
+        for task in OpenROADGPLParameter.find_task(project):
+            task.set_openroad_placedensity(0.40)

--- a/scgallery/designs/caliptra/constraints/datavault/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/caliptra/constraints/datavault/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 1600
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/caliptra/constraints/keyvault/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/caliptra/constraints/keyvault/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 1600
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/caliptra/constraints/sha512/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/caliptra/constraints/sha512/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 3600
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/dynamic_node/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/dynamic_node/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 1000
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/dynamic_node/dynamic_node.py
+++ b/scgallery/designs/dynamic_node/dynamic_node.py
@@ -23,6 +23,9 @@ class DynamicNodeDesign(Design):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 

--- a/scgallery/designs/gcd/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/gcd/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 690
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/gcd/gcd.py
+++ b/scgallery/designs/gcd/gcd.py
@@ -17,6 +17,9 @@ class GCDDesign(Design):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 

--- a/scgallery/designs/heartbeat/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/heartbeat/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 200
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/heartbeat/heartbeat.py
+++ b/scgallery/designs/heartbeat/heartbeat.py
@@ -18,6 +18,9 @@ class HeartbeatDesign(Design):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 

--- a/scgallery/designs/ibex/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/ibex/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 3300
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk_i]
+
+create_clock -name core_clock -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock core_clock $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock core_clock [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/ibex/ibex.py
+++ b/scgallery/designs/ibex/ibex.py
@@ -52,6 +52,9 @@ class IBEXDesign(GalleryDesign):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 
@@ -68,6 +71,7 @@ class IBEXDesign(GalleryDesign):
                 self.add_file("constraints/sky130hd.sdc")
 
         self.add_target_setup("freepdk45_nangate45", self.setup_freepdk45)
+        self.add_target_setup("gt2n_6t_w31", self.setup_gt2n)
         self.add_target_setup("asap7_asap7sc7p5t_rvt", self.setup_asap7)
         self.add_target_setup("ihp130_sg13g2_stdcell", self.setup_ihp130)
         self.add_target_setup("gf180_gf180mcu_fd_sc_mcu7t5v0", self.setup_gf180)
@@ -85,6 +89,9 @@ class IBEXDesign(GalleryDesign):
         project.constraint.area.set_aspectratio(0.25)
 
     def setup_gf180(self, project: ASIC):
+        ASICSynthesis.find_task(project).set_yosys_useslang(True)
+
+    def setup_gt2n(self, project: ASIC):
         ASICSynthesis.find_task(project).set_yosys_useslang(True)
 
     def setup_skywater130(self, project: ASIC):

--- a/scgallery/designs/jpeg/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/jpeg/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 2250
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/jpeg/jpeg.py
+++ b/scgallery/designs/jpeg/jpeg.py
@@ -32,6 +32,9 @@ class JPEGDesign(Design):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 

--- a/scgallery/designs/mock_alu/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/mock_alu/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,15 @@
+set clk_name clock
+set clk_port_name clock
+set clk_period 2350
+set clk_io_pct 0.2
+
+set clk_port [get_ports $clk_port_name]
+
+create_clock -name $clk_name -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock $clk_name $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock $clk_name [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/mock_alu/mock_alu.py
+++ b/scgallery/designs/mock_alu/mock_alu.py
@@ -29,6 +29,9 @@ class MockALUDesign(GalleryDesign):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 
@@ -45,6 +48,7 @@ class MockALUDesign(GalleryDesign):
                 self.add_file("constraints/sky130hd.sdc")
 
         self.add_target_setup("freepdk45_nangate45", self.setup_chisel)
+        self.add_target_setup("gt2n_6t_w31", self.setup_chisel)
         self.add_target_setup("asap7_asap7sc7p5t_rvt", self.setup_chisel)
         self.add_target_setup("ihp130_sg13g2_stdcell", self.setup_chisel)
         self.add_target_setup("gf180_gf180mcu_fd_sc_mcu7t5v0", self.setup_chisel)

--- a/scgallery/designs/openmsp430/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/openmsp430/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 3200
+set clk_io_pct 0.2
+
+set clk_port [get_ports dco_clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/openmsp430/openmsp430.py
+++ b/scgallery/designs/openmsp430/openmsp430.py
@@ -42,6 +42,9 @@ class OpenMSP430Design(Design):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 

--- a/scgallery/designs/picorv32/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/picorv32/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 1700
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/picorv32/picorv32.py
+++ b/scgallery/designs/picorv32/picorv32.py
@@ -21,6 +21,9 @@ class PicoRV32Design(Design):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 

--- a/scgallery/designs/qerv/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/qerv/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 650
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/qerv/qerv.py
+++ b/scgallery/designs/qerv/qerv.py
@@ -28,6 +28,9 @@ class QERVDesign(GalleryDesign):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 

--- a/scgallery/designs/riscv32i/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/riscv32i/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 2900
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/riscv32i/riscv32i.py
+++ b/scgallery/designs/riscv32i/riscv32i.py
@@ -42,6 +42,9 @@ class Riscv32iDesign(Design):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 

--- a/scgallery/designs/serv/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/serv/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 650
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/serv/serv.py
+++ b/scgallery/designs/serv/serv.py
@@ -39,6 +39,9 @@ class SERVDesign(Design):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 

--- a/scgallery/designs/spi/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/spi/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 250
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/spi/spi.py
+++ b/scgallery/designs/spi/spi.py
@@ -18,6 +18,9 @@ class SPIDesign(Design):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 

--- a/scgallery/designs/swerv/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/swerv/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 3700
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name core_clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock core_clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock core_clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/swerv/swerv.py
+++ b/scgallery/designs/swerv/swerv.py
@@ -75,6 +75,9 @@ class SwervDesign(GalleryDesign):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 
@@ -91,6 +94,7 @@ class SwervDesign(GalleryDesign):
                 self.add_file("constraints/sky130hd.sdc")
 
         self.add_target_setup("freepdk45_nangate45", self.setup_freepdk45)
+        self.add_target_setup("gt2n_6t_w31", self.setup_gt2n)
         self.add_target_setup("asap7_asap7sc7p5t_rvt", self.setup_asap7)
         self.add_target_setup("ihp130_sg13g2_stdcell", self.setup_ihp130)
         self.add_target_setup("gf180_gf180mcu_fd_sc_mcu7t5v0", self.setup_gf180)
@@ -98,6 +102,9 @@ class SwervDesign(GalleryDesign):
         self.add_target_setup("skywater130_sky130hd", self.setup_skywater130)
 
     def setup_freepdk45(self, project: ASIC):
+        ASICSynthesis.find_task(project).set_yosys_useslang(True)
+
+    def setup_gt2n(self, project: ASIC):
         ASICSynthesis.find_task(project).set_yosys_useslang(True)
 
     def setup_asap7(self, project: ASIC):

--- a/scgallery/designs/uart/constraints/gt2n_stdcells_w31_svt.sdc
+++ b/scgallery/designs/uart/constraints/gt2n_stdcells_w31_svt.sdc
@@ -1,0 +1,12 @@
+set clk_period 550
+set clk_io_pct 0.2
+
+set clk_port [get_ports clk]
+
+create_clock -name clk -period $clk_period $clk_port
+
+set non_clock_inputs [lsearch -inline -all -not -exact [all_inputs] $clk_port]
+set_input_delay [expr {$clk_period * $clk_io_pct}] -clock clk $non_clock_inputs
+set_output_delay [expr {$clk_period * $clk_io_pct}] -clock clk [all_outputs]
+
+set_driving_cell -lib_cell gt2_6t_buf_x1_w31_svt [all_inputs]

--- a/scgallery/designs/uart/uart.py
+++ b/scgallery/designs/uart/uart.py
@@ -21,6 +21,9 @@ class UARTDesign(Design):
             with self.active_fileset("sdc.asap7sc7p5t_rvt"):
                 self.add_file("constraints/asap7sc7p5t_rvt.sdc")
 
+            with self.active_fileset("sdc.gt2n_stdcells_w31_svt"):
+                self.add_file("constraints/gt2n_stdcells_w31_svt.sdc")
+
             with self.active_fileset("sdc.gf180mcu_fd_sc_mcu7t5v0_5LM"):
                 self.add_file("constraints/gf180mcu_fd_sc_mcu7t5v0.sdc")
 

--- a/scgallery/gallery.py
+++ b/scgallery/gallery.py
@@ -23,6 +23,7 @@ from siliconcompiler.schema.parametertype import NodeType
 from siliconcompiler.utils import default_credentials_file, paths, curation
 
 from scgallery.targets.freepdk45 import nangate45 as freepdk45_nangate45
+from scgallery.targets.gt2n import gt2n as gt2n_6t
 from scgallery.targets.gf180 import (
     gf180mcu_fd_sc_mcu7t5v0 as gf180_gf180mcu_fd_sc_mcu7t5v0,
     gf180mcu_fd_sc_mcu9t5v0 as gf180_gf180mcu_fd_sc_mcu9t5v0,
@@ -61,7 +62,8 @@ class Gallery:
                 ("asap7_asap7sc7p5t_rvt", asap7_asap7sc7p5t_rvt),
                 ("gf180_gf180mcu_fd_sc_mcu9t5v0", gf180_gf180mcu_fd_sc_mcu9t5v0),
                 ("gf180_gf180mcu_fd_sc_mcu7t5v0", gf180_gf180mcu_fd_sc_mcu7t5v0),
-                ("ihp130_sg13g2_stdcell", ihp130_sg13g2_stdcell)):
+                ("ihp130_sg13g2_stdcell", ihp130_sg13g2_stdcell),
+                ("gt2n_6t_w31", gt2n_6t)):
             self.add_target(name, target)
 
         self.__designs: Dict[str, Design] = {}

--- a/scgallery/targets/gt2n/__init__.py
+++ b/scgallery/targets/gt2n/__init__.py
@@ -1,0 +1,6 @@
+from siliconcompiler import ASIC
+from lambdapdk.gt2n.target import gt2n_demo
+
+
+def gt2n(proj: ASIC):
+    gt2n_demo(proj)

--- a/tests/test_gallery.py
+++ b/tests/test_gallery.py
@@ -97,7 +97,8 @@ def test_default_targets():
                                      "asap7_asap7sc7p5t_rvt",
                                      "gf180_gf180mcu_fd_sc_mcu9t5v0",
                                      "gf180_gf180mcu_fd_sc_mcu7t5v0",
-                                     "ihp130_sg13g2_stdcell"]
+                                     "ihp130_sg13g2_stdcell",
+                                     "gt2n_6t_w31"]
 
 
 def test_add_design():


### PR DESCRIPTION
https://github.com/siliconcompiler/scgallery/actions/runs/27430084089

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a new GT2N 6T W31 technology target across many gallery designs, with corresponding timing-constraint profiles and selectable target entries.
* **Chores**
  * Bumped a Python dependency requirement.
* **Tests**
  * Updated gallery tests to include the new GT2N target in the default target list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->