### PR TITLE
drop 3.9

### DIFF
--- a/.github/workflows/general_ci.yml
+++ b/.github/workflows/general_ci.yml
@@ -21,12 +21,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        # Python 3.9 is on macos-13 but not macos-latest (macos-14-arm64)
-        # https://github.com/actions/setup-python/issues/696#issuecomment-1637587760
-        exclude:
-          - { python: "3.9", os: "macos-latest" }
 
     runs-on: ${{ matrix.os }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ authors = [
 ]
 description = "Design gallery for SiliconCompiler"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 dependencies = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s supported Python versions to **3.10 and newer**.
  * Removed Python 3.9 from the supported test matrix, simplifying compatibility coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->