### PR TITLE
skip the two sky130 designs that time out in post-route antenna repair

### DIFF
--- a/.github/workflows/config/designs.json
+++ b/.github/workflows/config/designs.json
@@ -156,8 +156,11 @@
         "target": "ihp130_sg13g2_stdcell"
     },
     {
+        "cache": false,
         "design": "caliptra_datavault",
         "remote": false,
+        "skip": "Timed out on CI runner in route.detailed_antenna_repair (detailed routing alone uses most of the job budget)",
+        "skip_class": "resource",
         "target": "skywater130_sky130hd"
     },
     {
@@ -334,8 +337,11 @@
         "target": "ihp130_sg13g2_stdcell"
     },
     {
+        "cache": false,
         "design": "darksocv",
         "remote": false,
+        "skip": "Timed out on CI runner in route.detailed_antenna_repair (detailed routing alone uses most of the job budget)",
+        "skip_class": "resource",
         "target": "skywater130_sky130hd"
     },
     {


### PR DESCRIPTION
darksocv and caliptra_datavault on sky130 hit the 120 minute job timeout in route.detailed_antenna_repair, the node siliconcompiler PR #5226 adds after detailed routing. Neither is a functional failure: detailed routing itself takes 2532s and 3310s on these two, so most of the job budget is already spent before the repair node starts, and the repair loop can re-run detailed_route up to ant_reroute_iterations times.

Tagged skip_class resource rather than plain skip, since that is what this is -- the large-designs workflow will still exercise them on a runner with a longer timeout instead of dropping them permanently.

Measured cost of the new node on the sky130 designs that did pass, as context for how variable it is:
  aes        route.detailed 3167s  antenna repair  165s
  ibex       route.detailed 1924s  antenna repair  950s
  jpeg       route.detailed 1640s  antenna repair 1566s
On ihp130, the other PDK with a diode cell, it is 10-239s. sky130 is where
diode insertion drives the most rerouting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated resource handling for selected hardware configurations that time out during detailed antenna repair.
  * These configurations are now correctly marked to skip caching when the repair process cannot complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->