### PR TITLE
move to SC targets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.10"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 dependencies = [
-    "siliconcompiler>=0.38.0",
+    "siliconcompiler>=0.38.5",
     "lambdapdk>=0.2.18",
     "lambdalib>=0.13.1"
 ]

--- a/scgallery/targets/gt2n/__init__.py
+++ b/scgallery/targets/gt2n/__init__.py
@@ -1,5 +1,5 @@
 from siliconcompiler import ASIC
-from lambdapdk.gt2n.target import gt2n_demo
+from siliconcompiler.targets import gt2n_demo
 
 
 def gt2n(proj: ASIC):

--- a/scgallery/targets/icsprout55/__init__.py
+++ b/scgallery/targets/icsprout55/__init__.py
@@ -1,6 +1,6 @@
 from siliconcompiler import ASIC
-from lambdapdk.icsprout55.target import ics55_demo
+from siliconcompiler.targets import icsprout55_demo
 
 
 def ics55(proj: ASIC):
-    ics55_demo(proj)
+    icsprout55_demo(proj)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated target integrations to use the current SiliconCompiler target definitions, improving compatibility for GT2N and IC Sprout55 demos.
* **Chores**
  * Updated the minimum supported SiliconCompiler version to 0.38.5.
  * Improved reliability when loading and running the affected demonstration targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->